### PR TITLE
calculate oi instead of passing it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.12-rc14",
+  "version": "0.2.12-rc15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gainsnetwork/sdk",
-      "version": "0.2.12-rc14",
+      "version": "0.2.12-rc15",
       "dependencies": {
         "@ethersproject/providers": "^5.7.2",
         "ethcall": "^4.8.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.12-rc14",
+  "version": "0.2.12-rc15",
   "description": "Gains Network SDK",
   "main": "./lib/index.js",
   "files": [

--- a/src/trade/fees/borrowing/index.ts
+++ b/src/trade/fees/borrowing/index.ts
@@ -5,7 +5,6 @@ export type GetBorrowingFeeContext = {
   currentBlock: number;
   groups: BorrowingFee.Group[];
   pairs: BorrowingFee.Pair[];
-  openInterest: OpenInterest;
 };
 
 export const getBorrowingFee = (
@@ -15,12 +14,7 @@ export const getBorrowingFee = (
   initialAccFees: BorrowingFee.InitialAccFees,
   context: GetBorrowingFeeContext
 ): number => {
-  if (
-    !context.groups ||
-    !context.pairs ||
-    !context.openInterest ||
-    !context.pairs[pairIndex]
-  ) {
+  if (!context.groups || !context.pairs || !context.pairs[pairIndex]) {
     return 0;
   }
 
@@ -30,9 +24,13 @@ export const getBorrowingFee = (
 
   let fee = 0;
   if (!firstPairGroup || firstPairGroup.block > initialAccFees.block) {
+    const openInterest = pairs[pairIndex].oi;
     fee =
       (!firstPairGroup
-        ? getPairPendingAccFee(pairIndex, context.currentBlock, long, context)
+        ? getPairPendingAccFee(pairIndex, context.currentBlock, long, {
+            pairs,
+            openInterest,
+          })
         : long
         ? firstPairGroup.pairAccFeeLong
         : firstPairGroup.pairAccFeeShort) - initialAccFees.accPairFee;
@@ -181,13 +179,14 @@ const getPairGroupAccFeesDeltas = (
 
   let deltaGroup, deltaPair;
   if (i == pairGroups.length - 1) {
-    const { currentBlock, groups, pairs, openInterest } = context;
+    const { currentBlock, groups, pairs } = context;
+    const openInterest = pairs[pairIndex].oi;
     deltaGroup = getGroupPendingAccFee(group.groupIndex, currentBlock, long, {
       groups,
     });
     deltaPair = getPairPendingAccFee(pairIndex, currentBlock, long, {
       pairs,
-      openInterest: openInterest,
+      openInterest,
     });
   } else {
     const nextGroup = pairGroups[i + 1];


### PR DESCRIPTION
Removes requirement of passing `openInterest` to `getLiquidationPrice()` (OI is part of `pairBorrowingFees` that is passed already):

![image](https://github.com/user-attachments/assets/7c5c300a-cf49-44d3-bdc8-ff020f18d12e)

