### PR TITLE
Bugfix/allow no windows count check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gainsnetwork/sdk",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@ethersproject/providers": "^5.7.2",
         "ethcall": "^4.8.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gainsnetwork/sdk",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "dependencies": {
         "@ethersproject/providers": "^5.7.2",
         "ethcall": "^4.8.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Gains Network SDK",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Gains Network SDK",
   "main": "./lib/index.js",
   "files": [

--- a/src/trade/spread.ts
+++ b/src/trade/spread.ts
@@ -101,7 +101,7 @@ export const getSpreadWithPriceImpactP = (
 
   let activeOi = undefined;
 
-  if (oiWindowsSettings !== undefined && oiWindowsSettings?.windowsCount > 0) {
+  if (oiWindowsSettings !== undefined) {
     activeOi = getActiveOi(
       getCurrentOiWindowId(oiWindowsSettings),
       oiWindowsSettings.windowsCount,


### PR DESCRIPTION
This check is needless => `windowCount` is used further within `getActiveOi()` and is reacting properly to `0` value (activeOi equals `0` in that case which is expected)