### PR TITLE
add group name for degen pairs

### DIFF
--- a/src/contracts/utils/borrowingFees.ts
+++ b/src/contracts/utils/borrowingFees.ts
@@ -20,6 +20,8 @@ export const getBorrowingGroupName = (groupIndex: number): string => {
     "Forex GBP Majors",
     "Forex AUD",
     "Forex NZD",
+    "",
+    "Crypto Degens",
   ];
   return groupNamesByIndex[groupIndex - 1] || "Unknown";
 };

--- a/src/contracts/utils/borrowingFees.ts
+++ b/src/contracts/utils/borrowingFees.ts
@@ -21,7 +21,7 @@ export const getBorrowingGroupName = (groupIndex: number): string => {
     "Forex AUD",
     "Forex NZD",
     "",
-    "Crypto Degens",
+    "Crypto Degen",
   ];
   return groupNamesByIndex[groupIndex - 1] || "Unknown";
 };

--- a/src/contracts/utils/borrowingFees.ts
+++ b/src/contracts/utils/borrowingFees.ts
@@ -20,7 +20,6 @@ export const getBorrowingGroupName = (groupIndex: number): string => {
     "Forex GBP Majors",
     "Forex AUD",
     "Forex NZD",
-    "",
     "Crypto Degen",
   ];
   return groupNamesByIndex[groupIndex - 1] || "Unknown";


### PR DESCRIPTION
For now, degen pairs do not have group name. Added `Crypto Degens` in the `getBorrowingGroupName` method.