### PR TITLE
Bugfix/fix incorrect collateral ois

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.0.0-v10.rc2",
+  "version": "0.0.0-v10.rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gainsnetwork/sdk",
-      "version": "0.0.0-v10.rc2",
+      "version": "0.0.0-v10.rc6",
       "dependencies": {
         "@ethersproject/providers": "^5.7.2",
         "@gainsnetwork/contests": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.0.0-v10.rc5",
+  "version": "0.0.0-v10.rc6",
   "description": "Gains Network SDK",
   "main": "./lib/index.js",
   "files": [

--- a/src/backend/tradingVariables/converter.ts
+++ b/src/backend/tradingVariables/converter.ts
@@ -109,7 +109,7 @@ const convertCollateral = (
   },
   pairOis: convertPairOiArray(
     collateral.pairOis as any,
-    collateral.collateralConfig.decimals
+    parseInt(collateral.collateralConfig.precision)
   ),
 });
 


### PR DESCRIPTION
fix to incorrect collateral OIs

![image](https://github.com/user-attachments/assets/dc326e94-96ff-4f6d-a830-ffd71942fd2d)

BE input of `'1046781592400'` was producing FE value of `174463598733.33334` 

was happening because we were dividing `1046781592400` by `6` (or 18) instead of `10 ** 6`