### PR TITLE
Bugfix/fix incorrect max oi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.0.0-v10.rc6",
+  "version": "0.0.0-v10.rc8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gainsnetwork/sdk",
-      "version": "0.0.0-v10.rc6",
+      "version": "0.0.0-v10.rc8",
       "dependencies": {
         "@ethersproject/providers": "^5.7.2",
         "@gainsnetwork/contests": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/sdk",
-  "version": "0.0.0-v10.rc7",
+  "version": "0.0.0-v10.rc8",
   "description": "Gains Network SDK",
   "main": "./lib/index.js",
   "files": [

--- a/src/markets/oi/converter.ts
+++ b/src/markets/oi/converter.ts
@@ -71,7 +71,7 @@ export const convertPairOi = (
   collateralPrecision: number
 ): UnifiedPairOi => {
   return {
-    maxCollateral: Number(beforeV10.max) / collateralPrecision,
+    maxCollateral: Number(beforeV10.max) / 1e10,
     beforeV10Collateral: convertBeforeV10Collateral(
       beforeV10,
       collateralPrecision


### PR DESCRIPTION
`beforeV10.max` is always 1e10 => https://github.com/GainsNetwork-org/sdk/blob/feat/v10/src/backend/tradingVariables/converter.ts#L176